### PR TITLE
VCST-5090: MySqlConnector.MySqlException Incorrect table definition

### DIFF
--- a/src/VirtoCommerce.TaskManagement.Data.MySql/Migrations/20260511082306_Initial.Designer.cs
+++ b/src/VirtoCommerce.TaskManagement.Data.MySql/Migrations/20260511082306_Initial.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.TaskManagement.Data.Repositories;
@@ -11,15 +12,18 @@ using VirtoCommerce.TaskManagement.Data.Repositories;
 namespace VirtoCommerce.TaskManagement.Data.MySql.Migrations
 {
     [DbContext(typeof(TaskManagementDbContext))]
-    [Migration("20230823100734_Initial")]
+    [Migration("20260511082306_Initial")]
     partial class Initial
     {
+        /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "6.0.13")
+                .HasAnnotation("ProductVersion", "10.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
+
+            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("VirtoCommerce.TaskManagement.Data.Models.WorkTaskAttachmentEntity", b =>
                 {
@@ -106,6 +110,8 @@ namespace VirtoCommerce.TaskManagement.Data.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Number"));
+
                     b.Property<string>("ObjectId")
                         .HasMaxLength(128)
                         .HasColumnType("varchar(128)");
@@ -153,6 +159,8 @@ namespace VirtoCommerce.TaskManagement.Data.MySql.Migrations
                         .HasColumnType("varchar(128)");
 
                     b.HasKey("Id");
+
+                    b.HasAlternateKey("Number");
 
                     b.HasIndex("Completed");
 

--- a/src/VirtoCommerce.TaskManagement.Data.MySql/Migrations/20260511082306_Initial.cs
+++ b/src/VirtoCommerce.TaskManagement.Data.MySql/Migrations/20260511082306_Initial.cs
@@ -6,8 +6,10 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace VirtoCommerce.TaskManagement.Data.MySql.Migrations
 {
+    /// <inheritdoc />
     public partial class Initial : Migration
     {
+        /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AlterDatabase()
@@ -64,6 +66,7 @@ namespace VirtoCommerce.TaskManagement.Data.MySql.Migrations
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_WorkTask", x => x.Id);
+                    table.UniqueConstraint("AK_WorkTask_Number", x => x.Number);
                 })
                 .Annotation("MySql:CharSet", "utf8mb4");
 
@@ -154,6 +157,7 @@ namespace VirtoCommerce.TaskManagement.Data.MySql.Migrations
                 column: "WorkTaskId");
         }
 
+        /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(

--- a/src/VirtoCommerce.TaskManagement.Data.MySql/Migrations/TaskManagementDbContextModelSnapshot.cs
+++ b/src/VirtoCommerce.TaskManagement.Data.MySql/Migrations/TaskManagementDbContextModelSnapshot.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.TaskManagement.Data.Repositories;
 
@@ -16,8 +17,10 @@ namespace VirtoCommerce.TaskManagement.Data.MySql.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "6.0.13")
+                .HasAnnotation("ProductVersion", "10.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
+
+            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("VirtoCommerce.TaskManagement.Data.Models.WorkTaskAttachmentEntity", b =>
                 {
@@ -104,6 +107,8 @@ namespace VirtoCommerce.TaskManagement.Data.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Number"));
+
                     b.Property<string>("ObjectId")
                         .HasMaxLength(128)
                         .HasColumnType("varchar(128)");
@@ -151,6 +156,8 @@ namespace VirtoCommerce.TaskManagement.Data.MySql.Migrations
                         .HasColumnType("varchar(128)");
 
                     b.HasKey("Id");
+
+                    b.HasAlternateKey("Number");
 
                     b.HasIndex("Completed");
 

--- a/src/VirtoCommerce.TaskManagement.Data.MySql/VirtoCommerce.TaskManagement.Data.MySql.csproj
+++ b/src/VirtoCommerce.TaskManagement.Data.MySql/VirtoCommerce.TaskManagement.Data.MySql.csproj
@@ -14,4 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.TaskManagement.Data\VirtoCommerce.TaskManagement.Data.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Migrations\" />
+  </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.TaskManagement.Data.MySql/WorkTaskEntityConfiguration.cs
+++ b/src/VirtoCommerce.TaskManagement.Data.MySql/WorkTaskEntityConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VirtoCommerce.TaskManagement.Data.Models;
+
+namespace VirtoCommerce.TaskManagement.Data.MySql;
+
+public class WorkTaskEntityConfiguration : IEntityTypeConfiguration<WorkTaskEntity>
+{
+    public void Configure(EntityTypeBuilder<WorkTaskEntity> builder)
+    {
+        // MySQL requires AUTO_INCREMENT columns to be part of a key AT CREATE TABLE time.
+        // A separate unique index after CREATE TABLE is rejected. Declaring Number as an
+        // alternate key makes EF emit an inline UNIQUE constraint inside the CREATE TABLE.
+        builder.HasAlternateKey(x => x.Number);
+    }
+}


### PR DESCRIPTION
## Description
fix: MySqlConnector.MySqlException (0x80004005): Incorrect table definition; there can be only one auto column and it must be defined as a key


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5090
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.TaskManagement_3.1001.0-pr-27-20a3.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MySQL EF migrations/schema for `WorkTask.Number` by adding an inline unique constraint and regenerating the initial migration, which could affect database creation/migration behavior and data expectations around `Number` uniqueness.
> 
> **Overview**
> Fixes MySQL table creation failure for the `WorkTask.Number` auto-increment column by making `Number` an alternate key, causing EF to emit an inline `UNIQUE` constraint (`AK_WorkTask_Number`) during `CREATE TABLE` rather than relying on a post-create unique index.
> 
> Regenerates the MySQL initial migration and model snapshot (EF `ProductVersion` now `10.0.7` and MySQL identity annotations updated), and adds a MySQL-specific `WorkTaskEntityConfiguration` applied via `ApplyConfigurationsFromAssembly`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a3abe5baabb757e403606f2084fc58f548a0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->