### PR TITLE
VCST-5227: Task list sorting, default sort by created date, and due date filter fix

### DIFF
--- a/src/VirtoCommerce.TaskManagement.Web/App/package.json
+++ b/src/VirtoCommerce.TaskManagement.Web/App/package.json
@@ -22,8 +22,8 @@
     "@types/node": "^20.10.5",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
-    "@vc-shell/api-client-generator": "^2.0.6",
-    "@vc-shell/ts-config": "^2.0.6",
+    "@vc-shell/api-client-generator": "^2.0.10",
+    "@vc-shell/ts-config": "^2.0.10",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.6.0",
@@ -52,13 +52,12 @@
     "vue-tsc": "^3.2.5"
   },
   "dependencies": {
-    "@vc-shell/config-generator": "^2.0.6",
-    "@vc-shell/framework": "^2.0.6",
+    "@vc-shell/config-generator": "^2.0.10",
+    "@vc-shell/framework": "^2.0.10",
     "@vueuse/core": "^10.7.1",
     "@vueuse/integrations": "^10.7.1",
     "lodash-es": "^4.17.21",
     "moment": "^2.30.1",
-    "roboto-fontface": "^0.10.0",
     "vee-validate": "^4.12.4",
     "vue": "^3.5.30",
     "vue-router": "^5.0.3"

--- a/src/VirtoCommerce.TaskManagement.Web/App/package.json
+++ b/src/VirtoCommerce.TaskManagement.Web/App/package.json
@@ -22,8 +22,8 @@
     "@types/node": "^20.10.5",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
-    "@vc-shell/api-client-generator": "^2.0.10",
-    "@vc-shell/ts-config": "^2.0.10",
+    "@vc-shell/api-client-generator": "^2.1.0",
+    "@vc-shell/ts-config": "^2.1.0",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.6.0",
@@ -52,8 +52,8 @@
     "vue-tsc": "^3.2.5"
   },
   "dependencies": {
-    "@vc-shell/config-generator": "^2.0.10",
-    "@vc-shell/framework": "^2.0.10",
+    "@vc-shell/config-generator": "^2.1.0",
+    "@vc-shell/framework": "^2.1.0",
     "@vueuse/core": "^10.7.1",
     "@vueuse/integrations": "^10.7.1",
     "lodash-es": "^4.17.21",

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/archive-tasks/composables/useArchiveWorkTasks/index.ts
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/archive-tasks/composables/useArchiveWorkTasks/index.ts
@@ -9,7 +9,7 @@ export interface UseArchiveWorkTasksOptions extends UseBaseWorkTasksListOptions 
 export function useArchiveWorkTasks(options?: UseArchiveWorkTasksOptions): IUseBaseWorkTasksList {
   return useWorkTasksList({
     pageSize: options?.pageSize || 20,
-    sort: options?.sort || "modifiedDate:desc",
+    sort: options?.sort || "createdDate:DESC",
     defaultFilters: {
       isActive: false,
     },

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/archive-tasks/pages/archiveTasksList.vue
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/archive-tasks/pages/archiveTasksList.vue
@@ -42,7 +42,7 @@ const baseWorkTasksListRef = useTemplateRef("baseWorkTasksListRef");
 
 const { items, pagination, searchQuery, loadWorkTasks, loading, taskTypes, priorities } = useArchiveWorkTasks({
   pageSize: 20,
-  sort: "name:desc",
+  sort: "createdDate:DESC",
 });
 
 const title = computed(() => t("TASKS.PAGES.LIST.ARCHIVE_TITLE"));

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/my-archive-tasks/composables/useMyArchiveWorkTasks/index.ts
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/my-archive-tasks/composables/useMyArchiveWorkTasks/index.ts
@@ -9,7 +9,7 @@ export interface UseMyArchiveWorkTasksOptions extends UseBaseWorkTasksListOption
 export function useMyArchiveWorkTasks(options?: UseMyArchiveWorkTasksOptions): IUseBaseWorkTasksList {
   return useWorkTasksList({
     pageSize: options?.pageSize || 20,
-    sort: options?.sort || "modifiedDate:desc",
+    sort: options?.sort || "createdDate:DESC",
     defaultFilters: {
       isActive: false,
       onlyAssignedToMe: true,

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/my-archive-tasks/pages/myArchiveTasksList.vue
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/my-archive-tasks/pages/myArchiveTasksList.vue
@@ -42,7 +42,7 @@ const baseWorkTasksListRef = useTemplateRef("baseWorkTasksListRef");
 
 const { items, pagination, searchQuery, loadWorkTasks, loading, taskTypes, priorities } = useMyArchiveWorkTasks({
   pageSize: 20,
-  sort: "name:desc",
+  sort: "createdDate:DESC",
 });
 
 const title = computed(() => t("TASKS.PAGES.LIST.MY_ARCHIVE_TITLE"));

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/my-tasks/composables/useMyWorkTasks/index.ts
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/my-tasks/composables/useMyWorkTasks/index.ts
@@ -9,7 +9,7 @@ export interface UseMyWorkTasksOptions extends UseBaseWorkTasksListOptions {}
 export function useMyWorkTasks(options?: UseMyWorkTasksOptions): IUseBaseWorkTasksList {
   return useWorkTasksList({
     pageSize: options?.pageSize || 20,
-    sort: options?.sort || "modifiedDate:desc",
+    sort: options?.sort || "createdDate:DESC",
     defaultFilters: {
       onlyAssignedToMe: true,
     },

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/my-tasks/pages/myTasksList.vue
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/my-tasks/pages/myTasksList.vue
@@ -41,7 +41,7 @@ const baseWorkTasksListRef = useTemplateRef("baseWorkTasksListRef");
 
 const { items, pagination, searchQuery, loadWorkTasks, loading, taskTypes, priorities } = useMyWorkTasks({
   pageSize: 20,
-  sort: "name:desc",
+  sort: "createdDate:DESC",
 });
 
 const title = computed(() => t("MY_TASKS.PAGES.LIST.TITLE"));

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/tasks/components/BaseWorkTasksList.vue
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/tasks/components/BaseWorkTasksList.vue
@@ -7,7 +7,7 @@
     <VcDataTable
       v-model:active-item-id="selectedItemId"
       v-model:sort-field="sortField"
-      v-model:sort-order="sortOrderNumeric"
+      v-model:sort-order="sortOrder"
       :items="items"
       :loading="loading"
       :total-count="pagination.totalCount"
@@ -24,26 +24,31 @@
         id="number"
         :title="t('TASKS.PAGES.LIST.TABLE.HEADER.NUMBER')"
         width="80px"
+        sortable
       />
       <VcColumn
         id="type"
         :title="t('TASKS.PAGES.LIST.TABLE.HEADER.TYPE')"
         width="250px"
+        sortable
       />
       <VcColumn
         id="name"
         :title="t('TASKS.PAGES.LIST.TABLE.HEADER.NAME')"
         width="250px"
+        sortable
       />
       <VcColumn
         id="responsibleName"
         :title="t('TASKS.PAGES.LIST.TABLE.HEADER.ASSIGNEE')"
         width="200px"
+        sortable
       />
       <VcColumn
         id="priority"
         :title="t('TASKS.PAGES.LIST.TABLE.HEADER.PRIORITY')"
         width="100px"
+        sortable
       >
         <template #cell="{ item }">
           <CellTaskPriority :priority="(item as WorkTask).priority" />
@@ -53,6 +58,7 @@
         id="status"
         :title="t('TASKS.PAGES.LIST.TABLE.HEADER.STATUS')"
         width="120px"
+        sortable
       >
         <template #cell="{ item }">
           <TaskStatus :item="item as WorkTask" />
@@ -74,7 +80,13 @@
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { debounce } from "lodash-es";
-import { IBladeToolbar, useBlade, UseDataTablePaginationReturn, GlobalFilterConfig } from "@vc-shell/framework";
+import {
+  IBladeToolbar,
+  useBlade,
+  useDataTableSort,
+  UseDataTablePaginationReturn,
+  GlobalFilterConfig,
+} from "@vc-shell/framework";
 import {
   TaskPriority,
   TaskType,
@@ -125,10 +137,13 @@ const { openBlade } = useBlade();
 
 const selectedItemId = ref<string>();
 
-// Sorting: initial values from searchQuery
-const sortField = ref<string>(props.searchQuery.sort?.split(":")[0] || "modifiedDate");
-const sortOrderNumeric = ref<0 | 1 | -1>(props.searchQuery.sort?.includes("desc") ? -1 : 1);
-const sortExpression = computed(() => `${sortField.value}:${sortOrderNumeric.value === -1 ? "DESC" : "ASC"}`);
+// Sorting — initial values derived from searchQuery.sort ("field:DIRECTION"),
+// defaulting to createdDate DESC so newly created tasks always stay on top.
+const [initialSortField, initialSortDirection] = (props.searchQuery.sort ?? "createdDate:DESC").split(":");
+const { sortField, sortOrder, sortExpression } = useDataTableSort({
+  initialField: initialSortField || "createdDate",
+  initialDirection: initialSortDirection?.toUpperCase() === "ASC" ? "ASC" : "DESC",
+});
 
 // Filters — bound to VcDataTable's :global-filters / @filter
 const currentFilters = ref<CurrentFilters>({});

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/tasks/components/BaseWorkTasksList.vue
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/tasks/components/BaseWorkTasksList.vue
@@ -121,8 +121,8 @@ export interface Props {
 interface CurrentFilters {
   type?: string;
   priority?: string;
-  startDate?: string;
-  endDate?: string;
+  startDueDate?: Date;
+  endDueDate?: Date;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -151,7 +151,9 @@ const currentFilters = ref<CurrentFilters>({});
 // Global filter panel config — rebuilt when props.taskTypes / props.priorities change.
 // Shape: { id, label, filter: { options?, range? } } per GlobalFilterConfig.
 // - `type` / `priority` → single-select (no `multiple: true`, preserving old UX).
-// - `dueDate` → date-range; VcDataTable emits values as two separate keys (startDate, endDate).
+// - `dueDate` → date-range; the `range` tuple names the keys VcDataTable emits in @filter
+//   and they MUST match WorkTaskSearchCriteria's API fields (startDueDate / endDueDate),
+//   otherwise the server silently ignores them and the grid stays unfiltered.
 const globalFiltersConfig = computed<GlobalFilterConfig[]>(() => [
   {
     id: "type",
@@ -173,17 +175,20 @@ const globalFiltersConfig = computed<GlobalFilterConfig[]>(() => [
     id: "dueDate",
     label: t("TASKS.PAGES.LIST.TABLE.FILTER.DUE_DATE.TITLE"),
     filter: {
-      range: ["startDate", "endDate"] as [string, string],
+      range: ["startDueDate", "endDueDate"] as [string, string],
     },
   },
 ]);
 
 async function onFilter(event: { filters: Record<string, unknown> }) {
+  // Date-range filter emits ISO date strings; convert to Date for the API criteria.
+  const startDueDate = event.filters.startDueDate as string | undefined;
+  const endDueDate = event.filters.endDueDate as string | undefined;
   currentFilters.value = {
     type: event.filters.type as string | undefined,
     priority: event.filters.priority as string | undefined,
-    startDate: event.filters.startDate as string | undefined,
-    endDate: event.filters.endDate as string | undefined,
+    startDueDate: startDueDate ? new Date(startDueDate) : undefined,
+    endDueDate: endDueDate ? new Date(endDueDate) : undefined,
   };
   await reload();
 }

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/tasks/components/BaseWorkTasksList.vue
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/tasks/components/BaseWorkTasksList.vue
@@ -180,15 +180,26 @@ const globalFiltersConfig = computed<GlobalFilterConfig[]>(() => [
   },
 ]);
 
+function toLocalDueDateBound(value: string | undefined, endOfDay = false): Date | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return new Date(
+    d.getUTCFullYear(),
+    d.getUTCMonth(),
+    d.getUTCDate(),
+    endOfDay ? 23 : 0,
+    endOfDay ? 59 : 0,
+    endOfDay ? 59 : 0,
+    endOfDay ? 999 : 0,
+  );
+}
+
 async function onFilter(event: { filters: Record<string, unknown> }) {
-  // Date-range filter emits ISO date strings; convert to Date for the API criteria.
-  const startDueDate = event.filters.startDueDate as string | undefined;
-  const endDueDate = event.filters.endDueDate as string | undefined;
   currentFilters.value = {
     type: event.filters.type as string | undefined,
     priority: event.filters.priority as string | undefined,
-    startDueDate: startDueDate ? new Date(startDueDate) : undefined,
-    endDueDate: endDueDate ? new Date(endDueDate) : undefined,
+    startDueDate: toLocalDueDateBound(event.filters.startDueDate as string | undefined),
+    endDueDate: toLocalDueDateBound(event.filters.endDueDate as string | undefined, true),
   };
   await reload();
 }

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/tasks/composables/useWorkTasks/index.ts
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/tasks/composables/useWorkTasks/index.ts
@@ -33,7 +33,7 @@ export function useWorkTasksList(options?: UseBaseWorkTasksListOptions): IUseBas
   const pageSize = options?.pageSize || 20;
   const searchQuery = ref<WorkTaskSearchCriteria>({
     take: pageSize,
-    sort: options?.sort || "modifiedDate:desc",
+    sort: options?.sort || "createdDate:DESC",
     skip: 0,
     ...options?.defaultFilters,
   } as WorkTaskSearchCriteria);

--- a/src/VirtoCommerce.TaskManagement.Web/App/src/modules/tasks/pages/workTasksList.vue
+++ b/src/VirtoCommerce.TaskManagement.Web/App/src/modules/tasks/pages/workTasksList.vue
@@ -41,7 +41,7 @@ const baseWorkTasksListRef = useTemplateRef("baseWorkTasksListRef");
 
 const { items, pagination, searchQuery, loadWorkTasks, loading, taskTypes, priorities } = useWorkTasksList({
   pageSize: 20,
-  sort: "name:desc",
+  sort: "createdDate:DESC",
 });
 
 const title = computed(() => t("TASKS.PAGES.LIST.TITLE"));

--- a/src/VirtoCommerce.TaskManagement.Web/App/yarn.lock
+++ b/src/VirtoCommerce.TaskManagement.Web/App/yarn.lock
@@ -3986,9 +3986,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vc-shell/api-client-generator@npm:^2.0.10":
-  version: 2.0.10
-  resolution: "@vc-shell/api-client-generator@npm:2.0.10"
+"@vc-shell/api-client-generator@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@vc-shell/api-client-generator@npm:2.1.0"
   dependencies:
     chalk: "npm:^2.4.2"
     cross-spawn: "npm:^7.0.3"
@@ -3998,13 +3998,13 @@ __metadata:
     vite-plugin-dts: "npm:^3.6.4"
   bin:
     api-client-generator: dist/api-client-generator.js
-  checksum: 10/41648f51ba7094d74859ce4fdac816537349091a85ffcdee619fcfd31fbddd4494fc84a77977c5dfff3973abc7dbf2063d55056a5cb065b68e305be6a3c8cd31
+  checksum: 10/c0a01be955a6a8725637fe6d712528d468b39774f634b2c2f970fe54e6f979e7e659bf258a73035cb81b1022cf2debc9ea0cefcc5a94dc456869b470b9157c33
   languageName: node
   linkType: hard
 
-"@vc-shell/config-generator@npm:^2.0.10":
-  version: 2.0.10
-  resolution: "@vc-shell/config-generator@npm:2.0.10"
+"@vc-shell/config-generator@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@vc-shell/config-generator@npm:2.1.0"
   dependencies:
     "@babel/parser": "npm:^7.27.0"
     "@vitejs/plugin-vue": "npm:^5.2.3"
@@ -4014,13 +4014,13 @@ __metadata:
     vite-plugin-circular-dependency: "npm:^0.5.0"
     vite-plugin-mkcert: "npm:^1.17.1"
     vue: "npm:^3.5.30"
-  checksum: 10/6cfd3187b603faf747296efabab74c5377511731b1ec9137832ed2046d7800aeed392a53a292207ce23ced297b95d874024a3494fca9eef7bfca2a0f1080a059
+  checksum: 10/d0c84b9a83292d06fe77fd756cb6e7cdd3179f20186750ddf5c327911dde41ec38dcb699a60164ad5bb80d267a8e39244f92140d08f3191288f827110be50f7d
   languageName: node
   linkType: hard
 
-"@vc-shell/framework@npm:^2.0.10":
-  version: 2.0.10
-  resolution: "@vc-shell/framework@npm:2.0.10"
+"@vc-shell/framework@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@vc-shell/framework@npm:2.1.0"
   dependencies:
     "@floating-ui/dom": "npm:^1.7.4"
     "@floating-ui/vue": "npm:^1.0.6"
@@ -4084,14 +4084,14 @@ __metadata:
       optional: false
   bin:
     vc-check-locales: dist/scripts/check-locales.cjs
-  checksum: 10/19dcf8cf9b0588ab7926a4b8a5d8123628bff76d4159f5122ea9178c7709b1623d4527e1615d8be994ee142cfe1b0d6cc210d5351a537b0313413a52ed3992e7
+  checksum: 10/9fdf3238b88f24befeb30988ef3a75098eb79a0133d10351ade8df884c44a0d766d8a6f10c3ccfeacc3a8b32045517e08f6fbb0910ca9122b19eda3af4bcb84d
   languageName: node
   linkType: hard
 
-"@vc-shell/ts-config@npm:^2.0.10":
-  version: 2.0.10
-  resolution: "@vc-shell/ts-config@npm:2.0.10"
-  checksum: 10/470a638c7adfa27b40425460c0922c55d76482a4bd1f2eabe22bd20900097f9667c344fd6f0d81ffcb916a15baf11d1ddf913ea8ae85961ac9634d47fde1c799
+"@vc-shell/ts-config@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@vc-shell/ts-config@npm:2.1.0"
+  checksum: 10/7ef47061e93a0be49e22347de541f5693628151ee00de6327dc15a0ce1945b397565a920548649f310d764d0348aa37b560d8a1895b4fbeed5bc15fa3950c4c0
   languageName: node
   linkType: hard
 
@@ -11542,10 +11542,10 @@ __metadata:
     "@types/node": "npm:^20.10.5"
     "@typescript-eslint/eslint-plugin": "npm:^6.16.0"
     "@typescript-eslint/parser": "npm:^6.16.0"
-    "@vc-shell/api-client-generator": "npm:^2.0.10"
-    "@vc-shell/config-generator": "npm:^2.0.10"
-    "@vc-shell/framework": "npm:^2.0.10"
-    "@vc-shell/ts-config": "npm:^2.0.10"
+    "@vc-shell/api-client-generator": "npm:^2.1.0"
+    "@vc-shell/config-generator": "npm:^2.1.0"
+    "@vc-shell/framework": "npm:^2.1.0"
+    "@vc-shell/ts-config": "npm:^2.1.0"
     "@vitejs/plugin-vue": "npm:^5.2.3"
     "@vue/eslint-config-prettier": "npm:^10.2.0"
     "@vue/eslint-config-typescript": "npm:^14.6.0"

--- a/src/VirtoCommerce.TaskManagement.Web/App/yarn.lock
+++ b/src/VirtoCommerce.TaskManagement.Web/App/yarn.lock
@@ -3986,9 +3986,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vc-shell/api-client-generator@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "@vc-shell/api-client-generator@npm:2.0.6"
+"@vc-shell/api-client-generator@npm:^2.0.10":
+  version: 2.0.10
+  resolution: "@vc-shell/api-client-generator@npm:2.0.10"
   dependencies:
     chalk: "npm:^2.4.2"
     cross-spawn: "npm:^7.0.3"
@@ -3997,14 +3997,14 @@ __metadata:
     vite: "npm:^6.3.3"
     vite-plugin-dts: "npm:^3.6.4"
   bin:
-    api-client-generator: ./dist/api-client-generator.js
-  checksum: 10/7bd3d92b5bb5756a7d87860d1111735bd2d32399ef766c85c9a0e1fdbb186fb816239252f21f740779cbf442fa6751d4a7e367a05c1a5f8416f439a0c6e8d695
+    api-client-generator: dist/api-client-generator.js
+  checksum: 10/41648f51ba7094d74859ce4fdac816537349091a85ffcdee619fcfd31fbddd4494fc84a77977c5dfff3973abc7dbf2063d55056a5cb065b68e305be6a3c8cd31
   languageName: node
   linkType: hard
 
-"@vc-shell/config-generator@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "@vc-shell/config-generator@npm:2.0.6"
+"@vc-shell/config-generator@npm:^2.0.10":
+  version: 2.0.10
+  resolution: "@vc-shell/config-generator@npm:2.0.10"
   dependencies:
     "@babel/parser": "npm:^7.27.0"
     "@vitejs/plugin-vue": "npm:^5.2.3"
@@ -4014,13 +4014,13 @@ __metadata:
     vite-plugin-circular-dependency: "npm:^0.5.0"
     vite-plugin-mkcert: "npm:^1.17.1"
     vue: "npm:^3.5.30"
-  checksum: 10/236dfb327792e808814494f0e0b421abaa9e62c6d36f9475752668cdd3536f862892485746ac10789de82c1314bd90d70429050f5908d2ab637dd1cec66f9af3
+  checksum: 10/6cfd3187b603faf747296efabab74c5377511731b1ec9137832ed2046d7800aeed392a53a292207ce23ced297b95d874024a3494fca9eef7bfca2a0f1080a059
   languageName: node
   linkType: hard
 
-"@vc-shell/framework@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "@vc-shell/framework@npm:2.0.6"
+"@vc-shell/framework@npm:^2.0.10":
+  version: 2.0.10
+  resolution: "@vc-shell/framework@npm:2.0.10"
   dependencies:
     "@floating-ui/dom": "npm:^1.7.4"
     "@floating-ui/vue": "npm:^1.0.6"
@@ -4083,15 +4083,15 @@ __metadata:
     vue-router:
       optional: false
   bin:
-    vc-check-locales: ./dist/scripts/check-locales.cjs
-  checksum: 10/281fda1913edd0e33999cdca2117bef032c8a0cd0a8dec98b644e12a4a552c4c0437fd370d8b999e40355f95254132ec72f0eb077241b0a7bec5eda8f736f552
+    vc-check-locales: dist/scripts/check-locales.cjs
+  checksum: 10/19dcf8cf9b0588ab7926a4b8a5d8123628bff76d4159f5122ea9178c7709b1623d4527e1615d8be994ee142cfe1b0d6cc210d5351a537b0313413a52ed3992e7
   languageName: node
   linkType: hard
 
-"@vc-shell/ts-config@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "@vc-shell/ts-config@npm:2.0.6"
-  checksum: 10/78d3a991f09e7d75578dc676e243de639683cd7f0ddbd5d8905622d3743720e5ba9a7f887cfac2e58688da1411e6274863a2d17e2cb01a832eaee6263844c452
+"@vc-shell/ts-config@npm:^2.0.10":
+  version: 2.0.10
+  resolution: "@vc-shell/ts-config@npm:2.0.10"
+  checksum: 10/470a638c7adfa27b40425460c0922c55d76482a4bd1f2eabe22bd20900097f9667c344fd6f0d81ffcb916a15baf11d1ddf913ea8ae85961ac9634d47fde1c799
   languageName: node
   linkType: hard
 
@@ -11549,10 +11549,10 @@ __metadata:
     "@types/node": "npm:^20.10.5"
     "@typescript-eslint/eslint-plugin": "npm:^6.16.0"
     "@typescript-eslint/parser": "npm:^6.16.0"
-    "@vc-shell/api-client-generator": "npm:^2.0.6"
-    "@vc-shell/config-generator": "npm:^2.0.6"
-    "@vc-shell/framework": "npm:^2.0.6"
-    "@vc-shell/ts-config": "npm:^2.0.6"
+    "@vc-shell/api-client-generator": "npm:^2.0.10"
+    "@vc-shell/config-generator": "npm:^2.0.10"
+    "@vc-shell/framework": "npm:^2.0.10"
+    "@vc-shell/ts-config": "npm:^2.0.10"
     "@vitejs/plugin-vue": "npm:^5.2.3"
     "@vue/eslint-config-prettier": "npm:^10.2.0"
     "@vue/eslint-config-typescript": "npm:^14.6.0"

--- a/src/VirtoCommerce.TaskManagement.Web/App/yarn.lock
+++ b/src/VirtoCommerce.TaskManagement.Web/App/yarn.lock
@@ -10643,13 +10643,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"roboto-fontface@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "roboto-fontface@npm:0.10.0"
-  checksum: 10/e29faa2c424ff58c7953cdf6b0a03695e3d723a4977fa955f807d7859b82065543c871cce2a2ebcb6a0e2c1a81ad0fe59d748ffc84d58661b17a42d87c0c9b8d
-  languageName: node
-  linkType: hard
-
 "robust-predicates@npm:^3.0.2":
   version: 3.0.3
   resolution: "robust-predicates@npm:3.0.3"
@@ -11572,7 +11565,6 @@ __metadata:
     moment: "npm:^2.30.1"
     postcss: "npm:^8.4.32"
     prettier: "npm:^3.1.1"
-    roboto-fontface: "npm:^0.10.0"
     sass: "npm:^1.87.0"
     tailwindcss: "npm:^3.4.0"
     tsx: "npm:^4.7.1"


### PR DESCRIPTION
## Summary

Improves the Tasks list UX across all four lists (Active, My, Archive, My archive — all share `BaseWorkTasksList.vue`) and fixes a filtering defect.

## Changes

### feat: column sorting + default sort by created date
- All data columns are now sortable (number, type, name, assignee, priority, status, due date) via the `useDataTableSort` composable.
- Every list defaults to `createdDate:DESC`, so newly created tasks always appear on top (previously sorted by name/modifiedDate).

### fix: due date filter not applied
- The Filters → Due date range was bound to `startDate` / `endDate`, which are **not** fields of `WorkTaskSearchCriteria`. The server silently ignored them and the grid stayed unfiltered.
- Now bound to the real API fields `startDueDate` / `endDueDate`, with the emitted ISO strings converted to `Date`.
- Type and Priority filters were unaffected (their keys already matched the criteria fields).

### chore(deps): upgrade @vc-shell to 2.0.10
- Required for the `useDataTableSort` composable; also drops the unused `roboto-fontface` dependency.

## Testing
- `vue-tsc --noEmit` passes with no errors.

## Notes
- Checkboxes + bulk delete were intentionally **not** included: the API exposes only single-id delete (`DELETE /api/task-management` with one id and per-task authorization). Bulk selection/delete will follow once a backend bulk-delete endpoint is available.
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.TaskManagement_3.1004.0-pr-29-db7e.zip